### PR TITLE
Meta Field is not a String

### DIFF
--- a/src/Model/Table/FilesTable.php
+++ b/src/Model/Table/FilesTable.php
@@ -120,10 +120,6 @@ class FilesTable extends Table
             ->integer('size')
             ->allowEmptyString('size');
 
-        $validator
-            ->scalar('meta')
-            ->allowEmptyString('meta');
-
         return $validator;
     }
 


### PR DESCRIPTION
Though it is stored as such in the DB.
In the entity world it is a PHP object.